### PR TITLE
Update Dockerfile example to build reliably

### DIFF
--- a/howto/docker.rst
+++ b/howto/docker.rst
@@ -23,12 +23,13 @@ Docker image for Gauge
     # Install Java.
     RUN apt-get update && apt-get install -q -y \
         openjdk-8-jdk \
-        sudo \
-        apt-transport-https
+        apt-transport-https \
+        gnupg \
+        ca-certificates
 
     # Install gauge
     RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys 023EDB0B && \
-        echo deb https://dl.bintray.com/gauge/gauge-deb stable main | sudo tee -a /etc/apt/sources.list
+        echo deb https://dl.bintray.com/gauge/gauge-deb stable main | tee -a /etc/apt/sources.list
 
     RUN apt-get update && apt-get install gauge
 

--- a/howto/docker.rst
+++ b/howto/docker.rst
@@ -24,7 +24,7 @@ Docker image for Gauge
     RUN apt-get update && apt-get install -q -y \
         openjdk-8-jdk \
         apt-transport-https \
-        gnupg \
+        gnupg2 \
         ca-certificates
 
     # Install gauge

--- a/howto/docker.rst
+++ b/howto/docker.rst
@@ -28,7 +28,7 @@ Docker image for Gauge
         ca-certificates
 
     # Install gauge
-    RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys 023EDB0B && \
+    RUN apt-key adv --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 023EDB0B && \
         echo deb https://dl.bintray.com/gauge/gauge-deb stable main | tee -a /etc/apt/sources.list
 
     RUN apt-get update && apt-get install gauge


### PR DESCRIPTION
This change fixes a crash that occurs with the currently recommended Dockerfile:
```
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/bin/appletviewer to provide /usr/bin/appletviewer (appletviewer) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/bin/jconsole to provide /usr/bin/jconsole (jconsole) in auto mode
Processing triggers for libc-bin (2.27-3ubuntu1) ...
Processing triggers for libgdk-pixbuf2.0-0:amd64 (2.36.11-2) ...
Removing intermediate container 7f801c815a3e
 ---> c56a71ee5021
Step 3/6 : RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys 023EDB0B &&     echo deb https://dl.bintray.com/gauge/gauge-deb stable main | sudo tee -a /etc/apt/sources.list
 ---> Running in e9aa31f9be14
E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
The command '/bin/sh -c apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys 023EDB0B &&     echo deb https://dl.bintray.com/gauge/gauge-deb stable main | sudo tee -a /etc/apt/sources.list' returned a non-zero code: 255
```

It also addresses a frequent issue, at least when building the Docker image on CircleCI, where the key servers were not accessible: https://discuss.linuxcontainers.org/t/3-0-unable-to-fetch-gpg-key-from-keyserver/2015/13

Lastly, it removes `sudo` which isn't necessary in Docker as it runs as administrator by default.