### PR TITLE
more reliable key retrieval for apt-get

### DIFF
--- a/howto/ci_cd/travis.rst
+++ b/howto/ci_cd/travis.rst
@@ -34,18 +34,38 @@ Creating tasks
     sudo: false
 
 .. code-block:: yaml
-  :caption: Linux
+  :caption: Linux (manual)
 
     language:
         - language_name
     os:
         - linux
     install:
-        - sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys 023EDB0B
+        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net --recv-keys 023EDB0B
         - echo deb https://dl.bintray.com/gauge/gauge-deb stable main | sudo tee -a /etc/apt/sources.list
         - sudo apt-get update
         - sudo apt-get install gauge
         - gauge install html-report
+
+    script: 'gauge run specs'
+
+    sudo: true
+
+.. code-block:: yaml
+  :caption: Linux (using Travis addson)
+
+    language:
+        - language_name
+    os:
+        - linux
+    addons:
+       apt:
+          update: true
+          sources:
+             - sourceline: "deb https://dl.bintray.com/gauge/gauge-deb stable main"
+               key_url: "http://ha.pool.sks-keyservers.net/pks/lookup?search=0x023EDB0B&op=get&options=mr"
+          packages:
+             - gauge
 
     script: 'gauge run specs'
 


### PR DESCRIPTION
using `pool.sks-servers.net` results intermittent timed out and connection issue. Switching to `ha.pool.sks-servers.net` is much more reliable.

Travis supports `addons` block which is more declarative and nicer way to deal with `apt-get`