### PR TITLE
Correct links to Gauge Gradle Plugin

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -381,8 +381,8 @@ Build tools
 .. _gradle:
 .. _ant_task:
 
-1. To use Gauge with `Maven <https://maven.apache.org/>`__, refer `Gauge Maven Plugin <https://github.com/getgauge/gauge-maven-plugin/blob/master/README.md>`__
-2. To use Gauge with `Gradle <https://gradle.org/>`__, refer `Gauge Gradle Plugin <https://github.com/manupsunny/gauge-gradle-plugin/blob/master/Readme.md>`__
+1. To use Gauge with `Maven <https://maven.apache.org/>`__, refer to `Gauge Maven Plugin <https://github.com/getgauge/gauge-maven-plugin/blob/master/README.md>`__
+2. To use Gauge with `Gradle <https://gradle.org/>`__, refer to `Gauge Gradle Plugin <https://github.com/getgauge/gauge-gradle-plugin/blob/master/Readme.md>`__
 3. To invoke gauge specs using `Ant <https://ant.apache.org/manual/Tasks/ant.html>`__
 
     .. code-block:: xml

--- a/installation.rst
+++ b/installation.rst
@@ -411,7 +411,7 @@ The spectacle plugin generates a readable HTML format of the specs.
 
         Read more `here <https://github.com/getgauge/spectacle>`__
 
-Gauge also supports the dependency management workflow with custom plugins for `Maven <https://github.com/getgauge/gauge-maven-plugin>`__ and `Gradle <https://github.com/manupsunny/gauge-gradle-plugin>`__.
+Gauge also supports the dependency management workflow with custom plugins for `Maven <https://github.com/getgauge/gauge-maven-plugin>`__ and `Gradle <https://github.com/getgauge/gauge-gradle-plugin>`__.
 
 Plugin Installation
 -------------------


### PR DESCRIPTION
Ownership/repo has now been transferred to `getgauge` account/org; so documentation links should be updated accordingly.

Fixed a minor English nitpick as well.