### PR TITLE
fixed indentation error

### DIFF
--- a/writing-specifications.rst
+++ b/writing-specifications.rst
@@ -175,7 +175,7 @@ cannot be used in step text.
 
 - ``"``
 - ``<``
-   - ``>``
+- ``>``
 
 Parameters
 -----------


### PR DESCRIPTION
an extra tab was slipped into the section describing what characters are reserved for parameters. Fixed the indentation.