### PR TITLE
Change "tee - a ..." to "tee -a ..."

### DIFF
--- a/partials/linux_installation.rst
+++ b/partials/linux_installation.rst
@@ -23,7 +23,7 @@ Gauge can be installed on any flavour of Linux using the shell script. The Follo
 
 .. code-block:: console
 
-    echo deb https://dl.bintray.com/gauge/gauge-deb stable main | sudo tee - a /etc/apt/sources.list
+    echo deb https://dl.bintray.com/gauge/gauge-deb stable main | sudo tee -a /etc/apt/sources.list
 
 .. code-block:: console
 


### PR DESCRIPTION
Fixes a very annoying bug in the Linux install instructions.