### PR TITLE
Fix typo in path in configuration.rst

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -31,7 +31,7 @@ Global configuration of Gauge (``gauge.properties``)
 ``gauge.properties`` is a ``.properties`` file that contains all Gauge specific configurations. 
 You can use or change the key value pairs present in this file to configure Gauge across all 
 Gauge projects. This file is located at ``~/.gauge/config`` in macOS and Linux systems and 
-at ``%APPDATA%\Gauge\config`` in Windows systems.
+at ``%APPDATA%\gauge\config`` in Windows systems.
 
 You can also use the ``gauge config`` command to change the value of a key in the ``gauge.properties`` file.
 


### PR DESCRIPTION
At least starting with version 1.1.4 gauge.properties is located under %APPDATA%\gauge\config and not (anymore) under %APPDATA%\Gauge\config