### PR TITLE
avoid using apt-key command in Debian

### DIFF
--- a/partials/linux_installation.rst
+++ b/partials/linux_installation.rst
@@ -9,16 +9,32 @@
 You can use one of the following ways to install Gauge on your
 linux distribution
 
-:installer-icon:`Install Using Shell Script APT_GET`
+:installer-icon:`Install Using Shell Script APT-GET`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
-    sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys 023EDB0B
-    echo deb https://dl.bintray.com/gauge/gauge-deb stable main | sudo tee -a /etc/apt/sources.list
+    sudo gpg --no-default-keyring --keyring /usr/share/keyrings/gauge-archive-keyring.gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 023EDB0B
+    sudo bash -c "echo deb [signed-by=/usr/share/keyrings/gauge-archive-keyring.gpg] https://dl.bintray.com/gauge/gauge-deb stable main > /etc/apt/sources.list.d/gauge.list"
     sudo apt-get update && sudo apt-get install gauge
 
-:installer-icon:`Install using NPM`
+Deprecated APT-KEY
+====================
+
+The command ``apt-key`` is now considered deprecated. If you installed Gauge before February 2021, you should remove the globally imported Gauge key using
+
+.. code-block:: console
+
+    sudo gpg --no-default-keyring --keyring /etc/apt/trusted.gpg --delete-key 023EDB0B
+
+and also remove the ``gauge-deb`` line from ``/etc/apt/sources.list`` to avoid a duplicate warning during ``apt-get update`` (W: Target Packages (...) is configured multiple times in /etc/apt/sources.list ...)
+
+.. code-block:: console
+
+    sudo sed --in-place '/https:\/\/dl.bintray.com\/gauge\/gauge-deb/d' /etc/apt/sources.list
+
+
+:installer-icon:`Install Using NPM`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can install Gauge by running the following command in Terminal.
@@ -28,7 +44,7 @@ You can install Gauge by running the following command in Terminal.
     npm install -g @getgauge/cli
 
 
-:installer-icon:`Install using DNF Package Manager`
+:installer-icon:`Install Using DNF Package Manager`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Install Gauge using dnf by running this command
@@ -38,7 +54,7 @@ Install Gauge using dnf by running this command
     sudo dnf install gauge
 
 
-:installer-icon:`Install using ZIP file`
+:installer-icon:`Install Using ZIP file`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Download the `Zip Installer <https://github.com/getgauge/gauge/releases/download/vGAUGE_LATEST_VERSION_PLACEHOLDER/gauge-GAUGE_LATEST_VERSION_PLACEHOLDER-linux.x86_64.zip>`__


### PR DESCRIPTION
use GPG and file names recommended by article https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution

also a minor change in title capitalization - to be consistent with rest of the Gauge documentation