### PR TITLE
Remove 3rd party library dependency from Java sample code for screenshots

### DIFF
--- a/writing-specifications.rst
+++ b/writing-specifications.rst
@@ -1901,10 +1901,9 @@ you can use appropriate driver APIs in the step implementation of the language r
         public String takeScreenshot() {
             TakesScreenshot driver = (TakesScreenshot) DriverFactory.getDriver();
             String screenshotFileName = String.format("screenshot-%s.png", UUID.randomUUID().toString());
-            File screenshotFile = new File(Paths.get(System.getenv("gauge_screenshots_dir"), screenshotFileName).toString());
-            File tmpFile = driver.getScreenshotAs(OutputType.FILE);
             try {
-                FileUtils.copyFile(tmpFile, screenshotFile);
+                Files.write(Path.of(System.getenv("gauge_screenshots_dir"), screenshotFileName),
+                        driver.getScreenshotAs(OutputType.BYTES));
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
- Only the Java sample code creates a temporary file but this is not necessary.
- `FileUtils` is from Apache Commons library. I think it is better to use `java.nio.file` in the Java standard library.